### PR TITLE
Fix a NullPointerException sometimes raised when breaking a floodlight

### DIFF
--- a/src/main/java/de/keridos/floodlights/client/render/block/RotatableBlockRenderer.java
+++ b/src/main/java/de/keridos/floodlights/client/render/block/RotatableBlockRenderer.java
@@ -3,6 +3,7 @@ package de.keridos.floodlights.client.render.block;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -87,7 +88,12 @@ public class RotatableBlockRenderer implements ISimpleBlockRenderingHandler {
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,
             RenderBlocks renderer) {
-        TileEntityFL l = (TileEntityFL) world.getTileEntity(x, y, z);
+        TileEntity tileEntity = world.getTileEntity(x, y, z);
+        if (!(tileEntity instanceof TileEntityFL)) {
+            return false;
+        }
+
+        TileEntityFL l = (TileEntityFL) tileEntity;
         int i1 = l.getOrientation().ordinal();
         int c = l.getColor();
         switch (i1) {


### PR DESCRIPTION
When I break a floodlight with a pickaxe on 2.6.1 I get a crash sometimes, for example: [crash-2024-08-19_14.49.21-client.txt](https://github.com/user-attachments/files/16659824/crash-2024-08-19_14.49.21-client.txt).

It is due to `world.getTileEntity` returning `null` [here](https://github.com/GTNewHorizons/FloodLights/blob/3e760496d21d2635fea99cf4e824224be8b6ea06/src/main/java/de/keridos/floodlights/client/render/block/RotatableBlockRenderer.java#L90). I grepped the code for some other mods, and it seems that they always check that the `TileEntity` returned by `getTileEntity` in `renderWorldBlock` is not null and of expected type.

This PR changes the code for `renderWorldBlock` to check for null (and for the type of the entity being returned).

I am no longer able to reproduce a crash with these changes.