### PR TITLE
fix flood lights te issues

### DIFF
--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
@@ -61,14 +61,16 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
         }
         if (worldObj.setBlock(x, y, z, ModBlocks.blockPhantomLight)) {
             TileEntity tile = worldObj.getTileEntity(x, y, z);
-            if (tile instanceof TileEntityPhantomLight) {
-                TileEntityPhantomLight light = (TileEntityPhantomLight) tile;
-                light.addSource(this.xCoord, this.yCoord, this.zCoord);
-                worldObj.markBlockRangeForRenderUpdate(x, y, z, x, y, z);
+            if (!(tile instanceof TileEntityPhantomLight)) {
+                tile = new TileEntityPhantomLight();
+                worldObj.setTileEntity(x, y, z, tile);
             }
-            return;
+            TileEntityPhantomLight light = (TileEntityPhantomLight) tile;
+            light.addSource(this.xCoord, this.yCoord, this.zCoord);
+            worldObj.markBlockRangeForRenderUpdate(x, y, z, x, y, z);
+        } else {
+            this.toggleUpdateRun();
         }
-        this.toggleUpdateRun();
     }
 
     @Override

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityPhantomLight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityPhantomLight.java
@@ -51,7 +51,11 @@ public class TileEntityPhantomLight extends TileEntity {
     }
 
     public void updateAllSources() {
-        for (int[] source : sources) {
+        // Create a copy of sources, because sources can be modified while we update it here.
+        ArrayList<int[]> sourcesCopy = new ArrayList<>();
+        sourcesCopy.addAll(sources);
+
+        for (int[] source : sourcesCopy) {
             TileEntity te = worldObj.getTileEntity(source[0], source[1], source[2]);
             if (te != null && te instanceof TileEntityMetaFloodlight) {
                 ((TileEntityMetaFloodlight) te).toggleUpdateRun();


### PR DESCRIPTION
After a long time of mysterious errors we were finally able to reproduce the issues and finally fix them. Not sure if the code here is best-practice, so feel free to correct me.

From the commit message:
- This can happen probably because the new TE will not be created fast enough after we set the block (or whatever).
- This fix finally works on our production server.
- It also fixes a `ConcurentModificationException` by using a copy of the actual `sources` list while it can be updated at `updateAllSources`