### PR TITLE
Fix cascade chunkloading

### DIFF
--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityGrowLight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityGrowLight.java
@@ -13,7 +13,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cofh.api.energy.IEnergyContainerItem;
 import de.keridos.floodlights.compatability.ModCompatibility;
 import de.keridos.floodlights.handler.ConfigHandler;
-import de.keridos.floodlights.init.ModBlocks;
 import de.keridos.floodlights.reference.Names;
 import de.keridos.floodlights.util.BlockPos;
 import de.keridos.floodlights.util.GeneralUtil;
@@ -39,17 +38,7 @@ public class TileEntityGrowLight extends TileEntityFLElectric {
         int x = this.xCoord + rotatedCoords[0];
         int y = this.yCoord + rotatedCoords[1];
         int z = this.zCoord + rotatedCoords[2];
-        if (remove) {
-            if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                light.removeSource(this.xCoord, this.yCoord, this.zCoord);
-            }
-        } else if (worldObj.getBlock(x, y, z).isAir(worldObj, x, y, z)) {
-            setLight(x, y, z);
-        } else if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-            TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-            light.addSource(this.xCoord, this.yCoord, this.zCoord);
-        }
+        setLightChecked(x, y, z, remove);
     }
 
     public void updateEntity() {

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
@@ -55,7 +55,9 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
     }
 
     public void setLight(int x, int y, int z) {
-        if (worldObj.getBlock(x, y, z) == ModBlocks.blockUVLightBlock) {
+        // Ensure we don't get or change a block which chunk hasn't been loaded yet to prevent cascade chunkloading
+        // and support `WorldServer.loadChunkOnRequest = false`.
+        if (!worldObj.blockExists(x, y, z) || worldObj.getBlock(x, y, z) == ModBlocks.blockUVLightBlock) {
             return;
         }
         if (worldObj.setBlock(x, y, z, ModBlocks.blockPhantomLight)) {
@@ -200,17 +202,7 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
             int x = this.xCoord + this.orientation.offsetX * i;
             int y = this.yCoord + this.orientation.offsetY * i;
             int z = this.zCoord + this.orientation.offsetZ * i;
-            if (remove) {
-                if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                    TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                    light.removeSource(this.xCoord, this.yCoord, this.zCoord);
-                }
-            } else if (worldObj.getBlock(x, y, z).isAir(worldObj, x, y, z)) {
-                setLight(x, y, z);
-            } else if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                light.addSource(this.xCoord, this.yCoord, this.zCoord);
-            } else if (worldObj.getBlock(x, y, z).isOpaqueCube()) {
+            if (!setLightChecked(x, y, z, remove)) {
                 break;
             }
         }
@@ -263,17 +255,7 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
                     int x = this.xCoord + rotatedCoords[0];
                     int y = this.yCoord + rotatedCoords[1];
                     int z = this.zCoord + rotatedCoords[2];
-                    if (remove) {
-                        if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                            TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                            light.removeSource(this.xCoord, this.yCoord, this.zCoord);
-                        }
-                    } else if (worldObj.getBlock(x, y, z).isAir(worldObj, x, y, z)) {
-                        setLight(x, y, z);
-                    } else if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                        TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                        light.addSource(this.xCoord, this.yCoord, this.zCoord);
-                    } else if (worldObj.getBlock(x, y, z).isOpaqueCube()) {
+                    if (!setLightChecked(x, y, z, remove)) {
                         if (i < 4) { // This is for canceling the long rangs beams
                             failedBeams[j] = true;
                         }
@@ -318,17 +300,7 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
                     int x = this.xCoord + rotatedCoords[0];
                     int y = this.yCoord + rotatedCoords[1];
                     int z = this.zCoord + rotatedCoords[2];
-                    if (remove) {
-                        if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                            TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                            light.removeSource(this.xCoord, this.yCoord, this.zCoord);
-                        }
-                    } else if (worldObj.getBlock(x, y, z).isAir(worldObj, x, y, z)) {
-                        setLight(x, y, z);
-                    } else if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                        TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                        light.addSource(this.xCoord, this.yCoord, this.zCoord);
-                    } else if (worldObj.getBlock(x, y, z).isOpaqueCube()) {
+                    if (!setLightChecked(x, y, z, remove)) {
                         break;
                     }
                 }
@@ -346,17 +318,7 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
                         int x = this.xCoord + this.orientation.offsetX;
                         int y = this.yCoord + this.orientation.offsetY;
                         int z = this.zCoord + this.orientation.offsetZ;
-                        if (remove) {
-                            if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                                TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                                light.removeSource(this.xCoord, this.yCoord, this.zCoord);
-                            }
-                        } else if (worldObj.getBlock(x, y, z).isAir(worldObj, x, y, z)) {
-                            setLight(x, y, z);
-                        } else if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                            TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                            light.addSource(this.xCoord, this.yCoord, this.zCoord);
-                        } else if (worldObj.getBlock(x, y, z).isOpaqueCube()) {
+                        if (!setLightChecked(x, y, z, remove)) {
                             return;
                         }
                     }
@@ -398,17 +360,7 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
                     int x = this.xCoord + rotatedCoords[0];
                     int y = this.yCoord + rotatedCoords[1];
                     int z = this.zCoord + rotatedCoords[2];
-                    if (remove) {
-                        if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                            TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                            light.removeSource(this.xCoord, this.yCoord, this.zCoord);
-                        }
-                    } else if (worldObj.getBlock(x, y, z).isAir(worldObj, x, y, z)) {
-                        setLight(x, y, z);
-                    } else if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                        TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                        light.addSource(this.xCoord, this.yCoord, this.zCoord);
-                    } else if (worldObj.getBlock(x, y, z).isOpaqueCube()) {
+                    if (!setLightChecked(x, y, z, remove)) {
                         if (i < 8) { // This is for canceling the long rangs beams
                             failedBeams[j] = true;
                         }
@@ -454,21 +406,33 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
                     int x = this.xCoord + rotatedCoords[0];
                     int y = this.yCoord + rotatedCoords[1];
                     int z = this.zCoord + rotatedCoords[2];
-                    if (remove) {
-                        if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                            TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                            light.removeSource(this.xCoord, this.yCoord, this.zCoord);
-                        }
-                    } else if (worldObj.getBlock(x, y, z).isAir(worldObj, x, y, z)) {
-                        setLight(x, y, z);
-                    } else if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                        TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                        light.addSource(this.xCoord, this.yCoord, this.zCoord);
-                    } else if (worldObj.getBlock(x, y, z).isOpaqueCube()) {
+                    if (!setLightChecked(x, y, z, remove)) {
                         break;
                     }
                 }
             }
         }
+    }
+
+    protected boolean setLightChecked(int x, int y, int z, boolean remove) {
+        if (!worldObj.blockExists(x, y, z)) {
+            return false;
+        }
+
+        if (remove) {
+            if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
+                TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
+                light.removeSource(this.xCoord, this.yCoord, this.zCoord);
+            }
+        } else if (worldObj.getBlock(x, y, z).isAir(worldObj, x, y, z)) {
+            setLight(x, y, z);
+        } else if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
+            TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
+            light.addSource(this.xCoord, this.yCoord, this.zCoord);
+        } else if (worldObj.getBlock(x, y, z).isOpaqueCube()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
@@ -60,15 +60,12 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
             return;
         }
         if (worldObj.setBlock(x, y, z, ModBlocks.blockPhantomLight)) {
-            TileEntity tile = worldObj.getTileEntity(x, y, z);
-            if (tile instanceof TileEntityPhantomLight) {
-                TileEntityPhantomLight light = (TileEntityPhantomLight) tile;
-                light.addSource(this.xCoord, this.yCoord, this.zCoord);
-                worldObj.markBlockRangeForRenderUpdate(x, y, z, x, y, z);
-            }
-            return;
+            TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
+            light.addSource(this.xCoord, this.yCoord, this.zCoord);
+            worldObj.markBlockRangeForRenderUpdate(x, y, z, x, y, z);
+        } else {
+            this.toggleUpdateRun();
         }
-        this.toggleUpdateRun();
     }
 
     @Override

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
@@ -7,7 +7,6 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.tileentity.TileEntity;
 
 import de.keridos.floodlights.handler.ConfigHandler;
 import de.keridos.floodlights.init.ModBlocks;

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityPhantomLight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityPhantomLight.java
@@ -51,7 +51,11 @@ public class TileEntityPhantomLight extends TileEntity {
     }
 
     public void updateAllSources() {
-        for (int[] source : sources) {
+        // Create a local copy as we remove sources while iterating them.
+        // Not best-practive but better then changing public facing methods.
+        ArrayList<int[]> sourcesCopy = new ArrayList<>(sources);
+
+        for (int[] source : sourcesCopy) {
             TileEntity te = worldObj.getTileEntity(source[0], source[1], source[2]);
             if (te != null && te instanceof TileEntityMetaFloodlight) {
                 ((TileEntityMetaFloodlight) te).toggleUpdateRun();

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntitySmallFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntitySmallFloodlight.java
@@ -9,7 +9,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cofh.api.energy.IEnergyContainerItem;
 import de.keridos.floodlights.compatability.ModCompatibility;
 import de.keridos.floodlights.handler.ConfigHandler;
-import de.keridos.floodlights.init.ModBlocks;
 import de.keridos.floodlights.reference.Names;
 import de.keridos.floodlights.util.MathUtil;
 import ic2.api.item.ElectricItem;
@@ -84,17 +83,7 @@ public class TileEntitySmallFloodlight extends TileEntityFLElectric {
             int x = this.xCoord + rotatedCoords[0];
             int y = this.yCoord + rotatedCoords[1];
             int z = this.zCoord + rotatedCoords[2];
-            if (remove) {
-                if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                    TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                    light.removeSource(this.xCoord, this.yCoord, this.zCoord);
-                }
-            } else if (worldObj.getBlock(x, y, z).isAir(worldObj, x, y, z)) {
-                setLight(x, y, z);
-            } else if (worldObj.getBlock(x, y, z) == ModBlocks.blockPhantomLight) {
-                TileEntityPhantomLight light = (TileEntityPhantomLight) worldObj.getTileEntity(x, y, z);
-                light.addSource(this.xCoord, this.yCoord, this.zCoord);
-            }
+            setLightChecked(x, y, z, remove);
         }
     }
 


### PR DESCRIPTION
This PR aims to fix a the cascade chunkloading issue. Whenever a light wants to set a phatom light in a chunk that is not yet loaded (can happen when traveling throw the world), it automatically loads the chunk. If in the new newly loaded chunk is another light, this loads the next again, and the next and so on ...

This also fixes a two possible crashes whenever `WorldServer.loadChunkOnRequest` is set to `false` like on my server. (Yes, it finally fixes my issues with Flood Lights / in combination with EIO Lights.)

Last but not least, this PR moves a piceace of code to a method to de-duplicate it (from about 10 similar usages).

As from my tests, this doesn't break existing worlds or the usage of the lights. But of course, this should be tested by someone else (and/or on Zeta) too.

For the reviewers: [This line of code](https://github.com/GTNewHorizons/FloodLights/pull/8/files#diff-569d39c6622bf5966cd4971a358038520f08d1a19ed69a4f2f36997116422a5cR56) is required to just get a static copy of the list as it get changed (sources get removed) while iterating it. There is no threading issue. Feel free to suggest any better way. I just wanted to not change the method signature of `void removeSource(x, y, z)`.