### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/floodlights/lang/en_US.lang
+++ b/src/main/resources/assets/floodlights/lang/en_US.lang
@@ -12,9 +12,13 @@ tile.floodlights:carbonFloodlight.name=Non-electric Floodlight
 tile.floodlights:electricFloodlight.name=Electric Floodlight
 tile.floodlights:smallElectricFloodlight.name=Small Electric Floodlight
 tile.floodlights:uvFloodlight.name=UV Floodlight
+tile.floodlights:smallElectricFloodlightMetaBlock.name=Flourescent Light
 tile.floodlights:smallElectricFloodlightMetaBlock_smallFluorescent.name=Small Flourescent Light
 tile.floodlights:smallElectricFloodlightMetaBlock_squareFluorescent.name=Square Flourescent Light
 tile.floodlights:growLight.name=Grow Light
+
+tile.floodlights:tilePhantomLight.name=Phantom Light
+tile.floodlights:tileUVLight.name=UV Light
 
 #GUI
 gui.floodlights:nonElectricFloodlightTimeRemaining=Time remaining


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.