### PR TITLE
correct wrong rf usage note and initial check

### DIFF
--- a/src/main/java/de/keridos/floodlights/handler/ConfigHandler.java
+++ b/src/main/java/de/keridos/floodlights/handler/ConfigHandler.java
@@ -57,7 +57,7 @@ public class ConfigHandler {
                 20,
                 0,
                 1000,
-                "Energy Usage in RF/t for the electric FloodLight (x4 for the cone floodlights)");
+                "Energy Usage in RF/t for the electric FloodLight (x2 for the cone floodlights)");
         energyUsageSmallFloodlight = config.getInt(
                 "energyUsageSmallFloodlight",
                 "general",

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityElectricFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityElectricFloodlight.java
@@ -124,7 +124,7 @@ public class TileEntityElectricFloodlight extends TileEntityFLElectric {
     public void changeMode(EntityPlayer player) {
         World world = this.getWorldObj();
         if (!world.isRemote) {
-            int realEnergyUsage = ConfigHandler.energyUsage * (mode == 0 ? 1 : 4);
+            int realEnergyUsage = ConfigHandler.energyUsage * (mode == 0 ? 1 : 2);
             removeSource(this.mode);
             mode = (mode == 2 ? 0 : mode + 1);
             if (active && (storage.getEnergyStored() >= realEnergyUsage || storageEU >= realEnergyUsage / 8.0D)) {


### PR DESCRIPTION
Just found while checking the code for adding support for wireless charger.

The actual usage is x2 and always was x2, so adjust the config hint and the initial check to match the actual usage.
https://github.com/GTNewHorizons/FloodLights/blob/626875bf701a5c5527e44c88c21ee750e4d06ff4/src/main/java/de/keridos/floodlights/tileentity/TileEntityElectricFloodlight.java#L30

If someone want to have it x4, I can add a config and default x2 (to prevent changes on existing bases).