### PR TITLE
Set `isBlockContainer` to true in all blocks spawning tile entities

### DIFF
--- a/src/main/java/de/keridos/floodlights/block/BlockCarbonFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockCarbonFloodlight.java
@@ -32,6 +32,7 @@ public class BlockCarbonFloodlight extends BlockFL implements ITileEntityProvide
     public BlockCarbonFloodlight() {
         super(Names.Blocks.CARBON_FLOODLIGHT, Material.rock, soundTypeMetal, 2.5F);
         setHarvestLevel("pickaxe", 1);
+        isBlockContainer = true;
     }
 
     @Override

--- a/src/main/java/de/keridos/floodlights/block/BlockElectricFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockElectricFloodlight.java
@@ -32,6 +32,7 @@ public class BlockElectricFloodlight extends BlockFL implements ITileEntityProvi
     public BlockElectricFloodlight() {
         super(Names.Blocks.ELECTRIC_FLOODLIGHT, Material.rock, soundTypeMetal, 2.5F);
         setHarvestLevel("pickaxe", 1);
+        isBlockContainer = true;
     }
 
     @Override

--- a/src/main/java/de/keridos/floodlights/block/BlockGrowLight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockGrowLight.java
@@ -38,6 +38,7 @@ public class BlockGrowLight extends BlockFL implements ITileEntityProvider {
     public BlockGrowLight() {
         super(Names.Blocks.GROW_LIGHT, Material.rock, soundTypeMetal, 2.5F);
         setHarvestLevel("pickaxe", 1);
+        isBlockContainer = true;
     }
 
     @Override

--- a/src/main/java/de/keridos/floodlights/block/BlockPhantomLight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockPhantomLight.java
@@ -28,6 +28,7 @@ public class BlockPhantomLight extends BlockFL implements ITileEntityProvider {
     public BlockPhantomLight(String name, Material material, SoundType soundType, float hardness) {
         super(name, material, soundType, hardness);
         setHarvestLevel("pickaxe", 1);
+        isBlockContainer = true;
     }
 
     @Override

--- a/src/main/java/de/keridos/floodlights/block/BlockSmallElectricFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockSmallElectricFloodlight.java
@@ -46,6 +46,7 @@ public class BlockSmallElectricFloodlight extends BlockFL implements ITileEntity
     public BlockSmallElectricFloodlight() {
         super(Names.Blocks.SMALL_ELECTRIC_FLOODLIGHT, Material.rock, soundTypeMetal, 2.5F);
         setHarvestLevel("pickaxe", 1);
+        isBlockContainer = true;
     }
 
     @Override

--- a/src/main/java/de/keridos/floodlights/block/BlockUVLight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockUVLight.java
@@ -31,6 +31,7 @@ public class BlockUVLight extends BlockFL implements ITileEntityProvider {
     public BlockUVLight() {
         super(Names.Blocks.UV_FLOODLIGHT, Material.rock, soundTypeMetal, 2.5F);
         setHarvestLevel("pickaxe", 1);
+        isBlockContainer = true;
     }
 
     @Override


### PR DESCRIPTION
All vanilla and most modded blocks implementing `ITileEntityProvider` set this, but `FloodLights` don't.

This is needed for `MatterManipulator` integration (RecursivePineapple/MatterManipulator#16) to work properly.