### PR TITLE
Preverse NBT data when block is broken

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,8 @@
 dependencies {
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.42:api') { transitive = false }
-    compileOnly('com.github.GTNewHorizons:EnderIO:2.9.2:dev') { transitive = false }
-    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.7.20-GTNH:dev') { transitive = false }
-    compileOnly('com.github.GTNewHorizons:waila:1.8.2:api') { transitive = false }
+    compileOnly('com.github.GTNewHorizons:EnderIO:2.9.12:dev') { transitive = false }
+    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.7.40-GTNH:dev') { transitive = false }
+    compileOnly('com.github.GTNewHorizons:waila:1.8.4:api') { transitive = false }
     compileOnly('curse.maven:agricraft-225635:2284133-sources')
     compileOnly('curse.maven:cofh-lib-220333:2388748')
     compileOnly('igwmod:IGW-Mod-1.7.10:1.1.12-34:userdev') { transitive = false }

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ developmentEnvironmentUserName = Developer
 
 # Enables using modern Java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
-enableModernJavaSyntax = false
+enableModernJavaSyntax = true
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ modId = FloodLights
 modGroup = de.keridos.floodlights
 
 # Whether to use modGroup as the maven publishing group.
-# Due to a history of using JitPack, the default is com.github.GTNewHorizons for all mods.
+# When false, com.github.GTNewHorizons is used.
 useModGroupForPublishing = false
 
 # Updates your build.gradle and settings.gradle automatically whenever an update is available.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.31'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.38'
 }
 
 

--- a/src/main/java/de/keridos/floodlights/block/BlockFL.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockFL.java
@@ -103,8 +103,7 @@ public class BlockFL extends Block {
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
         TileEntity tileEntity = world.getTileEntity(x, y, z);
 
-        if (tileEntity instanceof TileEntityFL) {
-            TileEntityFL tileEntityFL = ((TileEntityFL) tileEntity);
+        if (tileEntity instanceof TileEntityFL tileEntityFL) {
             NBTTagCompound nbtTagCompound = new NBTTagCompound();
             ArrayList<ItemStack> drops = new ArrayList<>();
 
@@ -122,8 +121,7 @@ public class BlockFL extends Block {
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entityLiving, ItemStack itemStack) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileEntityFL) {
-            TileEntityFL tileFL = ((TileEntityFL) world.getTileEntity(x, y, z));
+        if (tile instanceof TileEntityFL tileFL) {
             if (itemStack.hasTagCompound()) {
                 tileFL.readOwnFromNBT(itemStack.getTagCompound());
             }

--- a/src/main/java/de/keridos/floodlights/block/BlockGrowLight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockGrowLight.java
@@ -208,8 +208,7 @@ public class BlockGrowLight extends BlockFL implements ITileEntityProvider {
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entityLiving, ItemStack itemStack) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileEntityFL) {
-            TileEntityFL tileFL = ((TileEntityFL) world.getTileEntity(x, y, z));
+        if (tile instanceof TileEntityFL tileFL) {
             if (itemStack.hasTagCompound()) {
                 tileFL.readOwnFromNBT(itemStack.getTagCompound());
             }

--- a/src/main/java/de/keridos/floodlights/block/BlockGrowLight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockGrowLight.java
@@ -12,6 +12,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
@@ -206,9 +207,14 @@ public class BlockGrowLight extends BlockFL implements ITileEntityProvider {
 
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entityLiving, ItemStack itemStack) {
-        if (world.getTileEntity(x, y, z) instanceof TileEntityFL) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileEntityFL) {
+            TileEntityFL tileFL = ((TileEntityFL) world.getTileEntity(x, y, z));
+            if (itemStack.hasTagCompound()) {
+                tileFL.readOwnFromNBT(itemStack.getTagCompound());
+            }
             if (itemStack.hasDisplayName()) {
-                ((TileEntityFL) world.getTileEntity(x, y, z)).setCustomName(itemStack.getDisplayName());
+                tileFL.setCustomName(itemStack.getDisplayName());
             }
             ((TileEntityFL) world.getTileEntity(x, y, z)).setOrientation(ForgeDirection.DOWN);
         }

--- a/src/main/java/de/keridos/floodlights/block/BlockSmallElectricFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockSmallElectricFloodlight.java
@@ -268,8 +268,7 @@ public class BlockSmallElectricFloodlight extends BlockFL implements ITileEntity
 
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entityLiving, ItemStack itemStack) {
-        if (world.getTileEntity(x, y, z) instanceof TileEntityFL) {
-            TileEntityFL tileFL = ((TileEntityFL) world.getTileEntity(x, y, z));
+        if (world.getTileEntity(x, y, z) instanceof TileEntityFL tileFL) {
             if (itemStack.hasTagCompound()) {
                 tileFL.readOwnFromNBT(itemStack.getTagCompound());
             }
@@ -284,8 +283,7 @@ public class BlockSmallElectricFloodlight extends BlockFL implements ITileEntity
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
         TileEntity tileEntity = world.getTileEntity(x, y, z);
 
-        if (tileEntity instanceof TileEntityFL) {
-            TileEntityFL tileEntityFL = ((TileEntityFL) tileEntity);
+        if (tileEntity instanceof TileEntityFL tileEntityFL) {
             NBTTagCompound nbtTagCompound = new NBTTagCompound();
             ArrayList<ItemStack> drops = new ArrayList<>();
 

--- a/src/main/java/de/keridos/floodlights/block/BlockSmallElectricFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/block/BlockSmallElectricFloodlight.java
@@ -16,6 +16,8 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.MovingObjectPosition;
@@ -267,19 +269,35 @@ public class BlockSmallElectricFloodlight extends BlockFL implements ITileEntity
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entityLiving, ItemStack itemStack) {
         if (world.getTileEntity(x, y, z) instanceof TileEntityFL) {
-            if (itemStack.hasDisplayName()) {
-                ((TileEntityFL) world.getTileEntity(x, y, z)).setCustomName(itemStack.getDisplayName());
+            TileEntityFL tileFL = ((TileEntityFL) world.getTileEntity(x, y, z));
+            if (itemStack.hasTagCompound()) {
+                tileFL.readOwnFromNBT(itemStack.getTagCompound());
             }
-            ((TileEntityFL) world.getTileEntity(x, y, z))
-                    .setOrientation(ForgeDirection.getOrientation(getFacing(entityLiving)));
+            if (itemStack.hasDisplayName()) {
+                tileFL.setCustomName(itemStack.getDisplayName());
+            }
+            tileFL.setOrientation(ForgeDirection.getOrientation(getFacing(entityLiving)));
         }
     }
 
     @Override
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
-        ArrayList<ItemStack> drops = new ArrayList<ItemStack>();
-        drops.add(0, new ItemStack(ModBlocks.blockSmallElectricLight, 1, metadata));
-        return drops;
+        TileEntity tileEntity = world.getTileEntity(x, y, z);
+
+        if (tileEntity instanceof TileEntityFL) {
+            TileEntityFL tileEntityFL = ((TileEntityFL) tileEntity);
+            NBTTagCompound nbtTagCompound = new NBTTagCompound();
+            ArrayList<ItemStack> drops = new ArrayList<>();
+
+            tileEntityFL.writeOwnToNBT(nbtTagCompound);
+            ItemStack stack = new ItemStack(ModBlocks.blockSmallElectricLight, 1, metadata);
+            stack.setTagCompound(nbtTagCompound);
+
+            drops.add(stack);
+            return drops;
+        }
+
+        return super.getDrops(world, x, y, z, metadata, fortune);
     }
 
     @Override

--- a/src/main/java/de/keridos/floodlights/core/network/message/MessageTileEntityFL.java
+++ b/src/main/java/de/keridos/floodlights/core/network/message/MessageTileEntityFL.java
@@ -31,12 +31,12 @@ public class MessageTileEntityFL implements IMessage {
         @Override
         public IMessage onMessage(MessageTileEntityFL message, MessageContext ctx) {
             TileEntity tileEntity = FloodLights.proxy.getWorld().getTileEntity(message.x, message.y, message.z);
-            if (tileEntity instanceof TileEntityFL) {
-                ((TileEntityFL) tileEntity).setOrientation(message.orientation);
-                ((TileEntityFL) tileEntity).setState(message.state);
-                ((TileEntityFL) tileEntity).setCustomName(message.customName);
-                ((TileEntityFL) tileEntity).setOwner(message.owner);
-                ((TileEntityFL) tileEntity).setColor(message.color);
+            if (tileEntity instanceof TileEntityFL tileEntityFL) {
+                tileEntityFL.setOrientation(message.orientation);
+                tileEntityFL.setState(message.state);
+                tileEntityFL.setCustomName(message.customName);
+                tileEntityFL.setOwner(message.owner);
+                tileEntityFL.setColor(message.color);
             }
             if (tileEntity instanceof TileEntityCarbonFloodlight) {
                 ((TileEntityCarbonFloodlight) tileEntity).timeRemaining = message.timeRemaining;
@@ -55,8 +55,7 @@ public class MessageTileEntityFL implements IMessage {
     }
 
     public MessageTileEntityFL(TileEntity tileEntity) {
-        if (tileEntity instanceof TileEntityFL) {
-            TileEntityFL tileEntityFL = (TileEntityFL) tileEntity;
+        if (tileEntity instanceof TileEntityFL tileEntityFL) {
             this.x = tileEntityFL.xCoord;
             this.y = tileEntityFL.yCoord;
             this.z = tileEntityFL.zCoord;

--- a/src/main/java/de/keridos/floodlights/init/ModBlocks.java
+++ b/src/main/java/de/keridos/floodlights/init/ModBlocks.java
@@ -10,6 +10,7 @@ import de.keridos.floodlights.block.BlockPhantomLight;
 import de.keridos.floodlights.block.BlockSmallElectricFloodlight;
 import de.keridos.floodlights.block.BlockUVLight;
 import de.keridos.floodlights.block.BlockUVLightBlock;
+import de.keridos.floodlights.item.itemBlock.ItemBlockFL;
 import de.keridos.floodlights.item.itemBlock.ItemBlockSmallElectricMetaBlock;
 import de.keridos.floodlights.reference.Names;
 import de.keridos.floodlights.reference.Reference;
@@ -45,16 +46,16 @@ public class ModBlocks {
     }
 
     public static void registerBlocks() {
-        GameRegistry.registerBlock(blockElectricLight, Names.Blocks.ELECTRIC_FLOODLIGHT);
-        GameRegistry.registerBlock(blockCarbonLight, Names.Blocks.CARBON_FLOODLIGHT);
-        GameRegistry.registerBlock(blockPhantomLight, Names.Blocks.PHANTOM_LIGHT);
+        GameRegistry.registerBlock(blockElectricLight, ItemBlockFL.class, Names.Blocks.ELECTRIC_FLOODLIGHT);
+        GameRegistry.registerBlock(blockCarbonLight, ItemBlockFL.class, Names.Blocks.CARBON_FLOODLIGHT);
+        GameRegistry.registerBlock(blockPhantomLight, ItemBlockFL.class, Names.Blocks.PHANTOM_LIGHT);
         GameRegistry.registerBlock(
                 blockSmallElectricLight,
                 ItemBlockSmallElectricMetaBlock.class,
                 Names.Blocks.SMALL_ELECTRIC_FLOODLIGHT);
-        GameRegistry.registerBlock(blockUVLight, Names.Blocks.UV_FLOODLIGHT);
-        GameRegistry.registerBlock(blockUVLightBlock, Names.Blocks.UV_LIGHTBLOCK);
-        GameRegistry.registerBlock(blockGrowLight, Names.Blocks.GROW_LIGHT);
+        GameRegistry.registerBlock(blockUVLight, ItemBlockFL.class, Names.Blocks.UV_FLOODLIGHT);
+        GameRegistry.registerBlock(blockUVLightBlock, ItemBlockFL.class, Names.Blocks.UV_LIGHTBLOCK);
+        GameRegistry.registerBlock(blockGrowLight, ItemBlockFL.class, Names.Blocks.GROW_LIGHT);
     }
 
     public static void registerTileEntities() {

--- a/src/main/java/de/keridos/floodlights/item/itemBlock/ItemBlockFL.java
+++ b/src/main/java/de/keridos/floodlights/item/itemBlock/ItemBlockFL.java
@@ -4,24 +4,14 @@ import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemBlockWithMetadata;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
-/**
- * Created by Keridos on 14.07.2015. This Class
- */
-public class ItemBlockSmallElectricMetaBlock extends ItemBlockWithMetadata {
+public class ItemBlockFL extends ItemBlock {
 
-    private static final String[] subNames = { "smallFluorescent", "squareFluorescent" };
-
-    public ItemBlockSmallElectricMetaBlock(Block block) {
-        super(block, block);
-    }
-
-    @Override
-    public String getUnlocalizedName(ItemStack itemStack) {
-        return this.getUnlocalizedName() + "_" + subNames[itemStack.getItemDamage()];
+    public ItemBlockFL(Block block) {
+        super(block);
     }
 
     @Override

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityCarbonFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityCarbonFloodlight.java
@@ -27,8 +27,8 @@ public class TileEntityCarbonFloodlight extends TileEntityMetaFloodlight {
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound nbtTagCompound) {
-        super.readFromNBT(nbtTagCompound);
+    public void readOwnFromNBT(NBTTagCompound nbtTagCompound) {
+        super.readOwnFromNBT(nbtTagCompound);
         if (nbtTagCompound.hasKey(Names.NBT.TIME_REMAINING)) {
             this.timeRemaining = nbtTagCompound.getInteger(Names.NBT.TIME_REMAINING);
         }
@@ -41,8 +41,8 @@ public class TileEntityCarbonFloodlight extends TileEntityMetaFloodlight {
     }
 
     @Override
-    public void writeToNBT(NBTTagCompound nbtTagCompound) {
-        super.writeToNBT(nbtTagCompound);
+    public void writeOwnToNBT(NBTTagCompound nbtTagCompound) {
+        super.writeOwnToNBT(nbtTagCompound);
         nbtTagCompound.setInteger(Names.NBT.TIME_REMAINING, timeRemaining);
         NBTTagList list = new NBTTagList();
         ItemStack itemstack = getStackInSlot(0);

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityFL.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityFL.java
@@ -86,6 +86,10 @@ public class TileEntityFL extends TileEntity {
     @Override
     public void readFromNBT(NBTTagCompound nbtTagCompound) {
         super.readFromNBT(nbtTagCompound);
+        readOwnFromNBT(nbtTagCompound);
+    }
+
+    public void readOwnFromNBT(NBTTagCompound nbtTagCompound) {
         if (nbtTagCompound.hasKey(Names.NBT.DIRECTION)) {
             this.orientation = ForgeDirection.getOrientation(nbtTagCompound.getByte(Names.NBT.DIRECTION));
         }
@@ -112,6 +116,10 @@ public class TileEntityFL extends TileEntity {
     @Override
     public void writeToNBT(NBTTagCompound nbtTagCompound) {
         super.writeToNBT(nbtTagCompound);
+        writeOwnToNBT(nbtTagCompound);
+    }
+
+    public void writeOwnToNBT(NBTTagCompound nbtTagCompound) {
         nbtTagCompound.setByte(Names.NBT.DIRECTION, (byte) orientation.ordinal());
         nbtTagCompound.setBoolean(Names.NBT.INVERT, inverted);
         nbtTagCompound.setByte(Names.NBT.STATE, state);

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityFLElectric.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityFLElectric.java
@@ -40,8 +40,8 @@ public class TileEntityFLElectric extends TileEntityMetaFloodlight implements IE
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound nbtTagCompound) {
-        super.readFromNBT(nbtTagCompound);
+    public void readOwnFromNBT(NBTTagCompound nbtTagCompound) {
+        super.readOwnFromNBT(nbtTagCompound);
         storage.readFromNBT(nbtTagCompound);
         if (nbtTagCompound.hasKey(Names.NBT.STORAGE_EU)) {
             this.storageEU = nbtTagCompound.getDouble(Names.NBT.STORAGE_EU);
@@ -49,8 +49,8 @@ public class TileEntityFLElectric extends TileEntityMetaFloodlight implements IE
     }
 
     @Override
-    public void writeToNBT(NBTTagCompound nbtTagCompound) {
-        super.writeToNBT(nbtTagCompound);
+    public void writeOwnToNBT(NBTTagCompound nbtTagCompound) {
+        super.writeOwnToNBT(nbtTagCompound);
         storage.writeToNBT(nbtTagCompound);
         nbtTagCompound.setDouble(Names.NBT.STORAGE_EU, storageEU);
     }

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntityMetaFloodlight.java
@@ -75,8 +75,8 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound nbtTagCompound) {
-        super.readFromNBT(nbtTagCompound);
+    public void readOwnFromNBT(NBTTagCompound nbtTagCompound) {
+        super.readOwnFromNBT(nbtTagCompound);
         if (nbtTagCompound.hasKey(Names.NBT.STATE)) {
             this.active = (nbtTagCompound.getInteger(Names.NBT.STATE) != 0);
         }
@@ -94,8 +94,8 @@ public class TileEntityMetaFloodlight extends TileEntityFL implements ISidedInve
     }
 
     @Override
-    public void writeToNBT(NBTTagCompound nbtTagCompound) {
-        super.writeToNBT(nbtTagCompound);
+    public void writeOwnToNBT(NBTTagCompound nbtTagCompound) {
+        super.writeOwnToNBT(nbtTagCompound);
         nbtTagCompound.setBoolean(Names.NBT.WAS_ACTIVE, wasActive);
         nbtTagCompound.setByte(Names.NBT.STATE, state);
         NBTTagList list = new NBTTagList();

--- a/src/main/java/de/keridos/floodlights/tileentity/TileEntitySmallFloodlight.java
+++ b/src/main/java/de/keridos/floodlights/tileentity/TileEntitySmallFloodlight.java
@@ -22,16 +22,16 @@ public class TileEntitySmallFloodlight extends TileEntityFLElectric {
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound nbtTagCompound) {
-        super.readFromNBT(nbtTagCompound);
+    public void readOwnFromNBT(NBTTagCompound nbtTagCompound) {
+        super.readOwnFromNBT(nbtTagCompound);
         if (nbtTagCompound.hasKey(Names.NBT.ROTATION_STATE)) {
             this.rotationState = nbtTagCompound.getBoolean(Names.NBT.ROTATION_STATE);
         }
     }
 
     @Override
-    public void writeToNBT(NBTTagCompound nbtTagCompound) {
-        super.writeToNBT(nbtTagCompound);
+    public void writeOwnToNBT(NBTTagCompound nbtTagCompound) {
+        super.writeOwnToNBT(nbtTagCompound);
         nbtTagCompound.setBoolean(Names.NBT.ROTATION_STATE, rotationState);
     }
 

--- a/src/main/resources/assets/floodlights/lang/de_DE.lang
+++ b/src/main/resources/assets/floodlights/lang/de_DE.lang
@@ -30,6 +30,7 @@ gui.floodlights:minutesShort=m
 gui.floodlights:secondsShort=s
 gui.floodlights:growLightLighting=Normales Licht
 gui.floodlights:growLightDarkLight=Schwarzlicht
+gui.floodlights:tooltipConfigured=Konfiguriert
 
 # Creative Tabs
 itemGroup.floodlights=Flood Lights

--- a/src/main/resources/assets/floodlights/lang/en_US.lang
+++ b/src/main/resources/assets/floodlights/lang/en_US.lang
@@ -34,6 +34,7 @@ gui.floodlights:minutesShort=m
 gui.floodlights:secondsShort=s
 gui.floodlights:growLightLighting=Normal lighting
 gui.floodlights:growLightDarkLight=Black light
+gui.floodlights:tooltipConfigured=Configured
 
 # Creative Tabs
 itemGroup.floodlights=Flood Lights


### PR DESCRIPTION
Backports https://github.com/Keridos/FloodLights/commit/709621e9646bb0685ea314b23ebf80cb852987ac

Just shows a "Configured" tooltip, similar to Ender IO. Can not be reset yet and doesn't display storage. To be optimized in a future PR ™